### PR TITLE
Update storaged interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target/
 /.settings/
+/.vscode/
 /.classpath
 /.project
 /.pydevproject

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>uk.ac.rl.esc</groupId>
 	<artifactId>ids.r2dfoo</artifactId>
 	<packaging>war</packaging>
-	<version>2.0.2-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<name>IDS Server R2DFoo</name>
 
 	<description>Forked version of the original ICAT Data Service designed for Read-only, 2 level, Datafile based systems (hence R2DFoo).</description>
@@ -93,19 +93,19 @@
 		<dependency>
 			<groupId>org.icatproject</groupId>
 			<artifactId>ids.plugin</artifactId>
-			<version>1.5.0</version>
+			<version>2.0.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>uk.ac.rl.esc</groupId>
 			<artifactId>storaged-ids-plugin</artifactId>
-			<version>1.3.0</version>
+			<version>2.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -126,7 +126,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.2.12</version>
+			<version>1.5.5</version>
 		</dependency>
 
 		<dependency>
@@ -325,7 +325,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-war-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.3.2</version>
 			</plugin>
 
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>uk.ac.rl.esc</groupId>
 	<artifactId>ids.r2dfoo</artifactId>
 	<packaging>war</packaging>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>2.0.2-SNAPSHOT</version>
 	<name>IDS Server R2DFoo</name>
 
 	<description>Forked version of the original ICAT Data Service designed for Read-only, 2 level, Datafile based systems (hence R2DFoo).</description>
@@ -40,7 +40,7 @@
 		<connection>scm:git:${gitUrl}.git</connection>
 		<developerConnection>scm:git:${gitUrl}.git</developerConnection>
 		<url>${gitUrl}</url>
-		<tag>v2.0.1</tag>
+		<tag>HEAD</tag>
 	</scm>
 
 	<issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>uk.ac.rl.esc</groupId>
 	<artifactId>ids.r2dfoo</artifactId>
 	<packaging>war</packaging>
-	<version>2.0.2-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<name>IDS Server R2DFoo</name>
 
 	<description>Forked version of the original ICAT Data Service designed for Read-only, 2 level, Datafile based systems (hence R2DFoo).</description>

--- a/src/site/xhtml/release-notes.xhtml
+++ b/src/site/xhtml/release-notes.xhtml
@@ -6,6 +6,13 @@
 
 	<h1>IDS Server (ids.r2dfoo) Release Notes</h1>
 
+	<h2>3.0.0</h2>
+	<ul>
+		<li>Update storaged-ids-plugin to 2.0.0, which has an updated StorageD interface and an updated protobuf library.</li>
+		<li>Update other dependencies.</li>
+		<li>Update test environment settings to port 8080 to avoid complications caused by HTTPS certificates.</li>
+	</ul>
+
 	<h2>2.0.1</h2>
 	<p>Upgrade storaged-ids-plugin to 1.3.0, which fixes incompatibility of logback versions.</p>
 

--- a/src/test/resources/integration.parallel.run.properties
+++ b/src/test/resources/integration.parallel.run.properties
@@ -3,6 +3,7 @@ reader = db username root password password
 !useReaderForPerformance = true
 
 plugin.main.class = uk.ac.stfc.storaged.MainSDStorage
+# ${HOME} here actually means the system property testHome (I think!)
 plugin.main.dir = ${HOME}/data/ids/main/
 #plugin.archive.class = org.icatproject.ids.storage.ArchiveSDStorageV2
 plugin.archive.class = org.icatproject.ids.storage.ArchiveStorageDummy

--- a/src/test/resources/integration.run.properties
+++ b/src/test/resources/integration.run.properties
@@ -3,6 +3,7 @@ reader = db username root password password
 !useReaderForPerformance = true
 
 plugin.main.class = uk.ac.stfc.storaged.MainSDStorage
+# ${HOME} here actually means the system property testHome (I think!)
 plugin.main.dir = ${HOME}/data/ids/main/
 #plugin.archive.class = org.icatproject.ids.storage.ArchiveSDStorageV2
 plugin.archive.class = org.icatproject.ids.storage.ArchiveStorageDummy

--- a/src/test/resources/unit.tests.run.properties
+++ b/src/test/resources/unit.tests.run.properties
@@ -1,4 +1,4 @@
-icat.url = https://localhost:8181
+icat.url = http://localhost:8080
 rootUserNames = db/root
 reader = db username root password password
 !useReaderForPerformance = true

--- a/src/test/scripts/prepare_test.py
+++ b/src/test/scripts/prepare_test.py
@@ -43,7 +43,7 @@ for f in glob.glob("src/test/install/*.war"):
     os.remove(f)
 
 with open("src/test/install/setup.properties", "wt") as f:
-    print("secure         = true", file=f)
+    print("secure         = false", file=f)
     print("container      = Glassfish", file=f)
     print("home           = %s" % containerHome, file=f)
     print("port           = 4848", file=f)


### PR DESCRIPTION
This PR creates a new version of ids.r2dfoo (3.0.0) that includes an update version of the dls-ids-plugin with an updated version of the protobuf interface to work with the latest StorageD version.

Apart from that a few dependencies have been updated.

And the tests have changed to be run in HTTP rather than HTTPS to avoid problems with certificates.